### PR TITLE
Fix/no results prod

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,7 +17,6 @@ import parameters as p
 
 from url import encode_url
 
-
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ import parameters as p
 from url import encode_url
 
 import logging
-logging.basicConfig(filename='/logfile.log', level=logging.DEBUG, format='%(asctime)s %(levelname)s:%(message)s')
+logging.basicConfig(filename='logfile.log', level=logging.DEBUG, format='%(asctime)s %(levelname)s:%(message)s')
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,8 +17,6 @@ import parameters as p
 
 from url import encode_url
 
-import logging
-logging.basicConfig(filename='logfile.log', level=logging.DEBUG, format='%(asctime)s %(levelname)s:%(message)s')
 
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
@@ -71,19 +69,16 @@ def get_offers(search_params):
         
     driver.get(url)
 
-    WebDriverWait(driver, 15).until(
+    WebDriverWait(driver, 10).until(
         EC.presence_of_element_located((By.CLASS_NAME, "row.margenVerticales.resultadoOfertas.noMargingLaterales.seccionOferta"))
     )
     no_results_message = "No se encontraron resultados para su búsqueda."
+    
     try:
         WebDriverWait(driver, 10).until(
             EC.text_to_be_present_in_element((By.XPATH, "//div[@id='paginaOfertas']/h3"), "No se encontraron resultados para su búsqueda.")
         )
         no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
-        logging.info(f"{no_results_element}")
-        logging.info(f"Texto encontrado en el elemento: '{no_results_element.text}'")
-        logging.info(f"Inner HTML del elemento: {no_results_element.get_attribute('innerHTML')}")
-        cleaned_text = no_results_element.text.strip()
 
         if no_results_message in no_results_element.text:
             print("No se encontraron resultados.")
@@ -91,7 +86,6 @@ def get_offers(search_params):
             return json.dumps([])  # O retorna un JSON vacío, por ejemplo: json.dumps([])
         else:
             print("No se encontró el mensaje de 'No resultados'")
-            logging.info("No se encontró el mensaje de 'No resultados'")
         
     except Exception as e:
         print("No se encontró el mensaje de 'No resultados', continuando con el scraping.")

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,9 @@ import parameters as p
 
 from url import encode_url
 
+import logging
+logging.basicConfig(filename='/logfile.log', level=logging.DEBUG, format='%(asctime)s %(levelname)s:%(message)s')
+
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
@@ -74,12 +77,14 @@ def get_offers(search_params):
     no_results_message = "No se encontraron resultados para su búsqueda."
     try:
         no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
+        logging.info(f"{no_results_element}")
         if no_results_message in no_results_element.text:
             print("No se encontraron resultados.")
             driver.close()
             return json.dumps([])  # O retorna un JSON vacío, por ejemplo: json.dumps([])
         else:
             print("No se encontró el mensaje de 'No resultados'")
+            logging.info("No se encontró el mensaje de 'No resultados'")
         
     except Exception as e:
         print("No se encontró el mensaje de 'No resultados', continuando con el scraping.")

--- a/backend/main.py
+++ b/backend/main.py
@@ -68,7 +68,7 @@ def get_offers(search_params):
         
     driver.get(url)
 
-    WebDriverWait(driver, 10).until(
+    WebDriverWait(driver, 15).until(
         EC.presence_of_element_located((By.CLASS_NAME, "row.margenVerticales.resultadoOfertas.noMargingLaterales.seccionOferta"))
     )
     no_results_message = "No se encontraron resultados para su búsqueda."

--- a/backend/main.py
+++ b/backend/main.py
@@ -78,6 +78,9 @@ def get_offers(search_params):
     try:
         no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
         logging.info(f"{no_results_element}")
+        logging.info(f"Texto encontrado en el elemento: '{no_results_element.text}'")
+        cleaned_text = no_results_element.text.strip()
+        logging.info(f"{cleaned_text}")
         if no_results_message in no_results_element.text:
             print("No se encontraron resultados.")
             driver.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -76,14 +76,15 @@ def get_offers(search_params):
     )
     no_results_message = "No se encontraron resultados para su búsqueda."
     try:
-        WebDriverWait(driver, 5).until(
+        WebDriverWait(driver, 10).until(
             EC.text_to_be_present_in_element((By.XPATH, "//div[@id='paginaOfertas']/h3"), "No se encontraron resultados para su búsqueda.")
         )
         no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
         logging.info(f"{no_results_element}")
         logging.info(f"Texto encontrado en el elemento: '{no_results_element.text}'")
+        logging.info(f"Inner HTML del elemento: {no_results_element.get_attribute('innerHTML')}")
         cleaned_text = no_results_element.text.strip()
-        logging.info(f"{cleaned_text}")
+
         if no_results_message in no_results_element.text:
             print("No se encontraron resultados.")
             driver.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -69,7 +69,7 @@ def get_offers(search_params):
         
     driver.get(url)
 
-    WebDriverWait(driver, 10).until(
+    WebDriverWait(driver, 15).until(
         EC.presence_of_element_located((By.CLASS_NAME, "row.margenVerticales.resultadoOfertas.noMargingLaterales.seccionOferta"))
     )
     no_results_message = "No se encontraron resultados para su búsqueda."
@@ -77,7 +77,7 @@ def get_offers(search_params):
     try:
         no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
         if no_results_element:
-            WebDriverWait(driver, 10).until(
+            WebDriverWait(driver, 15).until(
                 EC.text_to_be_present_in_element((By.XPATH, "//div[@id='paginaOfertas']/h3"), "No se encontraron resultados para su búsqueda.")
             )
             no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
@@ -125,7 +125,7 @@ def get_details(offer_code):
     driver = init_driver()    
     driver.get(url)
 
-    WebDriverWait(driver, 10).until(
+    WebDriverWait(driver, 15).until(
         EC.presence_of_element_located((By.ID, 'nombreOferta'))
     )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -76,6 +76,9 @@ def get_offers(search_params):
     )
     no_results_message = "No se encontraron resultados para su búsqueda."
     try:
+        WebDriverWait(driver, 5).until(
+            EC.text_to_be_present_in_element((By.XPATH, "//div[@id='paginaOfertas']/h3"), "No se encontraron resultados para su búsqueda.")
+        )
         no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
         logging.info(f"{no_results_element}")
         logging.info(f"Texto encontrado en el elemento: '{no_results_element.text}'")

--- a/backend/main.py
+++ b/backend/main.py
@@ -75,9 +75,11 @@ def get_offers(search_params):
     no_results_message = "No se encontraron resultados para su búsqueda."
     
     try:
-        WebDriverWait(driver, 10).until(
-            EC.text_to_be_present_in_element((By.XPATH, "//div[@id='paginaOfertas']/h3"), "No se encontraron resultados para su búsqueda.")
-        )
+        no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
+        if no_results_element:
+            WebDriverWait(driver, 10).until(
+                EC.text_to_be_present_in_element((By.XPATH, "//div[@id='paginaOfertas']/h3"), "No se encontraron resultados para su búsqueda.")
+            )
         no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
 
         if no_results_message in no_results_element.text:

--- a/backend/main.py
+++ b/backend/main.py
@@ -80,14 +80,13 @@ def get_offers(search_params):
             WebDriverWait(driver, 10).until(
                 EC.text_to_be_present_in_element((By.XPATH, "//div[@id='paginaOfertas']/h3"), "No se encontraron resultados para su búsqueda.")
             )
-        no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
-
-        if no_results_message in no_results_element.text:
-            print("No se encontraron resultados.")
-            driver.close()
-            return json.dumps([])  # O retorna un JSON vacío, por ejemplo: json.dumps([])
-        else:
-            print("No se encontró el mensaje de 'No resultados'")
+            no_results_element = driver.find_element(By.XPATH, "//div[@id='paginaOfertas']/h3")
+            if no_results_message in no_results_element.text:
+                print("No se encontraron resultados.")
+                driver.close()
+                return json.dumps([])  # O retorna un JSON vacío, por ejemplo: json.dumps([])
+            else:
+                print("No se encontró el mensaje de 'No resultados'")
         
     except Exception as e:
         print("No se encontró el mensaje de 'No resultados', continuando con el scraping.")

--- a/backend/main.py
+++ b/backend/main.py
@@ -78,6 +78,8 @@ def get_offers(search_params):
             print("No se encontraron resultados.")
             driver.close()
             return json.dumps([])  # O retorna un JSON vacío, por ejemplo: json.dumps([])
+        else:
+            print("No se encontró el mensaje de 'No resultados'")
         
     except Exception as e:
         print("No se encontró el mensaje de 'No resultados', continuando con el scraping.")

--- a/backend/parameters.py
+++ b/backend/parameters.py
@@ -1,3 +1,3 @@
-USING_FIREFOX = True # C para chrome, F para Firefox
+USING_FIREFOX = False # C para chrome, F para Firefox
 GECKODRIVER_LOCATION="/usr/local/bin/geckodriver"
 # GECKODRIVER_LOCATION="/snap/bin/firefox.geckodriver"

--- a/backend/parameters.py
+++ b/backend/parameters.py
@@ -1,3 +1,3 @@
-USING_FIREFOX = False # C para chrome, F para Firefox
+USING_FIREFOX = True # C para chrome, F para Firefox
 GECKODRIVER_LOCATION="/usr/local/bin/geckodriver"
 # GECKODRIVER_LOCATION="/snap/bin/firefox.geckodriver"


### PR DESCRIPTION
* Se agregó WebDriverWait al mensaje "No se encontraron resultados para su búsqueda." para que el scraper lo alcance a encontrar en el ambiente de producción que es más lento que en local.